### PR TITLE
Feature/add version lock to status

### DIFF
--- a/assets/src/graphql/mutations/moveCandidate.ts
+++ b/assets/src/graphql/mutations/moveCandidate.ts
@@ -6,19 +6,33 @@ mutation MoveCandidate(
   $afterIndex: DisplayOrder, 
   $beforeIndex: DisplayOrder, 
   $destinationStatusId: ID,
-  $clientId: String!) {
+  $clientId: String!,
+  $sourceStatusVersion: Int!,
+  $destinationStatusVersion: Int) {
   moveCandidate(
     candidateId: $candidateId, 
     afterIndex: $afterIndex, 
     beforeIndex: $beforeIndex, 
     destinationStatusId: $destinationStatusId,
-    clientId: $clientId) {
-    id
-    email
-    jobId
-    position
-    displayOrder
-    statusId
+    clientId: $clientId,
+    sourceStatusVersion: $sourceStatusVersion,
+    destinationStatusVersion: $destinationStatusVersion) {
+    candidate {
+      id
+      email
+      jobId
+      position
+      displayOrder
+      statusId
+    }
+    sourceStatus {
+      id
+      lockVersion
+    }
+    destinationStatus {
+      id
+      lockVersion
+    }
   }
 }
 

--- a/assets/src/graphql/queries/getBoard.ts
+++ b/assets/src/graphql/queries/getBoard.ts
@@ -18,6 +18,7 @@ export const GET_BOARD = gql`
       jobId
       position
       label
+      lockVersion
     }
   }
 `

--- a/assets/src/graphql/subscriptions/candidateMoved.ts
+++ b/assets/src/graphql/subscriptions/candidateMoved.ts
@@ -12,6 +12,14 @@ subscription TestSubscription($jobId: ID!) {
       statusId
     }
     clientId
+    sourceStatus {
+      id
+      lockVersion
+    }
+    destinationStatus {
+      id
+      lockVersion
+    }
   }
 }
 `

--- a/assets/src/hooks/useBoard/types.ts
+++ b/assets/src/hooks/useBoard/types.ts
@@ -1,4 +1,4 @@
-import { Candidate } from '../../types'
+import { Candidate, Status } from '../../types'
 
 export interface SortedCandidates {
   [key: string]: Candidate[]
@@ -8,9 +8,15 @@ export interface CandidateMovedSubscription {
   candidateMoved: {
     clientId: string
     candidate: Candidate
+    sourceStatus: Status
+    destinationStatus: Status
   }
 }
 
 export interface MoveCandidateMutation {
-  moveCandidate: Candidate
+  moveCandidate: {
+    candidate: Candidate
+    sourceStatus: Status
+    destinationStatus: Status
+  }
 }

--- a/assets/src/hooks/useBoard/useBoardData.ts
+++ b/assets/src/hooks/useBoard/useBoardData.ts
@@ -2,22 +2,21 @@ import { Candidate, Job, Status } from '../../types'
 import { GET_BOARD } from '../../graphql/queries/getBoard'
 import { useQuery } from '@apollo/client'
 import { useSortedCandidates } from './useSortedCandidates'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
-export const useBoardLayout = (jobId: string) => {
-  const { loading, error, data } = useQuery<{
+export const useBoardData = (jobId: string) => {
+  const { loading, error } = useQuery<{
     job: Job
     candidates: Candidate[]
     statuses: Status[]
   }>(GET_BOARD, {
     variables: { jobId },
+    onCompleted(data) {
+      setJob(() => data?.job ?? null)
+      setCandidates(() => data?.candidates || [])
+      setStatuses(() => data?.statuses || [])
+    },
   })
-
-  useEffect(() => {
-    setJob(() => data?.job ?? null)
-    setCandidates(() => data?.candidates || [])
-    setStatuses(() => data?.statuses || [])
-  }, [data])
 
   const [job, setJob] = useState<Job | null>(null)
   const [candidates, setCandidates] = useState<Candidate[]>([])
@@ -37,14 +36,35 @@ export const useBoardLayout = (jobId: string) => {
     })
   }
 
+  const updateStatusVersion = (statusId: number, newVersion: number) => {
+    setStatuses(data => {
+      return data.map(x => {
+        if (x.id !== statusId) return x
+
+        return {
+          ...x,
+          lockVersion: newVersion,
+        }
+      })
+    })
+  }
+
   const sortedCandidates = useSortedCandidates(candidates, statuses)
+
+  const statusesById = statuses.reduce<{ [key: number]: Status }>((acc, status: Status) => {
+    acc[status.id] = status
+
+    return acc
+  }, {})
 
   return {
     loading,
     error,
     sortedCandidates,
     statuses,
+    statusesById,
     job,
     updateCandidatePosition,
+    updateStatusVersion,
   }
 }

--- a/assets/src/hooks/useBoard/useCandidateMovedSubscription.ts
+++ b/assets/src/hooks/useBoard/useCandidateMovedSubscription.ts
@@ -6,7 +6,8 @@ import { Candidate } from '../../types'
 export const useCandidateMovedSubscription = (
   jobId: string,
   clientId: string,
-  onCandidateMoved: (candidate: Candidate) => void
+  onCandidateMoved: (candidate: Candidate) => void,
+  onStatusUpdate: (statusId: number, newVersion: number) => void
 ) => {
   const handleOnSubscriptionData = (data: OnDataOptions<CandidateMovedSubscription>) => {
     const candidateMoved = data.data.data!.candidateMoved
@@ -15,6 +16,10 @@ export const useCandidateMovedSubscription = (
     if (clientId === candidateMoved.clientId) return
 
     onCandidateMoved(candidateMoved.candidate)
+
+    const { sourceStatus, destinationStatus } = candidateMoved
+    onStatusUpdate(sourceStatus.id, sourceStatus.lockVersion)
+    onStatusUpdate(destinationStatus.id, destinationStatus.lockVersion)
   }
 
   useSubscription<CandidateMovedSubscription>(CANDIDATE_MOVED, {

--- a/assets/src/pages/JobShow/index.tsx
+++ b/assets/src/pages/JobShow/index.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 import { Text } from '@welcome-ui/text'
 import { Flex } from '@welcome-ui/flex'
 import { Box } from '@welcome-ui/box'
-import { Candidate } from '../../types'
+import { Candidate, Status } from '../../types'
 import CandidateCard from '../../components/Candidate'
 import { Badge } from '@welcome-ui/badge'
 import { useBoard } from '../../hooks/useBoard'
@@ -30,58 +30,62 @@ function JobShow() {
       <DragDropContext onDragEnd={handleOnDragEnd}>
         <Box p={20}>
           <Flex gap={10}>
-            {statuses?.map(status => (
-              <Box
-                w={300}
-                border={1}
-                backgroundColor="white"
-                borderColor="neutral-30"
-                borderRadius="md"
-                overflow="hidden"
-                key={status.id}
-              >
-                <Flex
-                  p={10}
-                  borderBottom={1}
+            {Array.from(statuses)
+              .sort((a, b) => a.position - b.position)
+              .map((status: Status) => (
+                <Box
+                  w={300}
+                  border={1}
+                  backgroundColor="white"
                   borderColor="neutral-30"
-                  alignItems="center"
-                  justify="space-between"
+                  borderRadius="md"
+                  overflow="hidden"
+                  key={status.id}
                 >
-                  <Text color="black" m={0} textTransform="capitalize">
-                    {status.label}
-                  </Text>
-                  <Badge>{(sortedCandidates[status.id] || []).length}</Badge>
-                </Flex>
+                  <Flex
+                    p={10}
+                    borderBottom={1}
+                    borderColor="neutral-30"
+                    alignItems="center"
+                    justify="space-between"
+                  >
+                    <Text color="black" m={0} textTransform="capitalize">
+                      {status.label} - Version {status.lockVersion}
+                    </Text>
+                    <Badge>{(sortedCandidates[status.id] || []).length}</Badge>
+                  </Flex>
 
-                <Droppable droppableId={`${status.id}`}>
-                  {provided => (
-                    <div {...provided.droppableProps} ref={provided.innerRef}>
-                      <Flex direction="column" p={10} pb={0}>
-                        {sortedCandidates[status.id]?.map((candidate: Candidate, index: number) => (
-                          <Draggable
-                            key={candidate.id}
-                            draggableId={`${candidate.id}`}
-                            index={index}
-                          >
-                            {provided => (
-                              <div
-                                ref={provided.innerRef}
-                                {...provided.draggableProps}
-                                {...provided.dragHandleProps}
-                                style={provided.draggableProps.style}
+                  <Droppable droppableId={`${status.id}`}>
+                    {provided => (
+                      <div {...provided.droppableProps} ref={provided.innerRef}>
+                        <Flex direction="column" p={10} pb={0}>
+                          {sortedCandidates[status.id]?.map(
+                            (candidate: Candidate, index: number) => (
+                              <Draggable
+                                key={candidate.id}
+                                draggableId={`${candidate.id}`}
+                                index={index}
                               >
-                                <CandidateCard candidate={candidate} />
-                              </div>
-                            )}
-                          </Draggable>
-                        ))}
-                      </Flex>
-                      {provided.placeholder}
-                    </div>
-                  )}
-                </Droppable>
-              </Box>
-            ))}
+                                {provided => (
+                                  <div
+                                    ref={provided.innerRef}
+                                    {...provided.draggableProps}
+                                    {...provided.dragHandleProps}
+                                    style={provided.draggableProps.style}
+                                  >
+                                    <CandidateCard candidate={candidate} />
+                                  </div>
+                                )}
+                              </Draggable>
+                            )
+                          )}
+                        </Flex>
+                        {provided.placeholder}
+                      </div>
+                    )}
+                  </Droppable>
+                </Box>
+              ))}
           </Flex>
         </Box>
       </DragDropContext>

--- a/assets/src/types/index.ts
+++ b/assets/src/types/index.ts
@@ -7,6 +7,7 @@ export type Status = {
   id: number
   label: number
   position: number
+  lockVersion: number
 }
 
 export type Candidate = {

--- a/lib/wttj/candidates.ex
+++ b/lib/wttj/candidates.ex
@@ -21,7 +21,7 @@ defmodule Wttj.Candidates do
         candidate_id,
         before_index,
         after_index,
-        before_index_version,
+        source_status_version,
         destination_status_id \\ nil,
         destination_status_version \\ nil
       ) do
@@ -58,7 +58,7 @@ defmodule Wttj.Candidates do
             end
 
           # 2. Version check - fail fast if versions don't match
-          if source_status.lock_version != before_index_version or
+          if source_status.lock_version != source_status_version or
                (!is_nil(destination_status_version) &&
                   dest_status.lock_version != destination_status_version) do
             Repo.rollback(:version_mismatch)
@@ -72,9 +72,7 @@ defmodule Wttj.Candidates do
           }
 
           {:ok, updated_candidate} =
-            Repo.update(
-              Candidate.changeset(candidate, attrs)
-            )
+            Repo.update(Candidate.changeset(candidate, attrs))
 
           # 4. Increment both version numbers
           new_source_status_version = source_status.lock_version + 1

--- a/lib/wttj/candidates.ex
+++ b/lib/wttj/candidates.ex
@@ -90,8 +90,6 @@ defmodule Wttj.Candidates do
     new_version_number = status.lock_version + 1
 
     Repo.update!(Status.changeset(status, %{lock_version: new_version_number}))
-
-    # new_version_number
   end
 
   defp validate_status_owned_by_board(_candidate, nil), do: {:ok}

--- a/lib/wttj/candidates.ex
+++ b/lib/wttj/candidates.ex
@@ -38,8 +38,6 @@ defmodule Wttj.Candidates do
 
       result =
         Repo.transaction(fn ->
-          # if we've got this far, everythign is still valid
-
           # 1. Get both statuses with current versions
           source_status =
             from(s in Status,
@@ -65,9 +63,6 @@ defmodule Wttj.Candidates do
                   dest_status.lock_version != destination_status_version) do
             Repo.rollback(:version_mismatch)
           end
-
-          # IO.inspect("Candidate before updated:")
-          # IO.inspect(candidate)
 
           # 3. If we get here, versions match - do the update
 
@@ -100,10 +95,6 @@ defmodule Wttj.Candidates do
             dest_version: new_dest_status_version
           }
         end)
-
-      # IO.inspect(result)
-
-      # IO.inspect(result)
 
       case result do
         {:error, :version_mismatch} ->

--- a/lib/wttj/resolvers/job_tracking.ex
+++ b/lib/wttj/resolvers/job_tracking.ex
@@ -35,7 +35,9 @@ defmodule Wttj.Resolvers.JobTracking do
              args[:candidate_id],
              args[:before_index],
              args[:after_index],
-             args[:destination_status_id]
+             args[:before_index_version],
+             args[:destination_status_id],
+             args[:destination_status_version]
            ) do
       payload = %{
         candidate: candidate,

--- a/lib/wttj/schema.ex
+++ b/lib/wttj/schema.ex
@@ -30,7 +30,7 @@ defmodule Wttj.Schema do
 
   mutation do
     @desc "Move a candidate to a different position"
-    field :move_candidate, type: :candidate do
+    field :move_candidate, type: :move_candidate_result do
       arg(:candidate_id, non_null(:id))
       arg(:before_index, :display_order)
       arg(:after_index, :display_order)

--- a/lib/wttj/schema.ex
+++ b/lib/wttj/schema.ex
@@ -34,8 +34,11 @@ defmodule Wttj.Schema do
       arg(:candidate_id, non_null(:id))
       arg(:before_index, :display_order)
       arg(:after_index, :display_order)
-      arg(:destination_status_id, :id)
       arg(:client_id, non_null(:string))
+      arg(:source_status_version, non_null(:integer))
+
+      arg(:destination_status_id, :id)
+      arg(:destination_status_version, :integer)
 
       resolve(&Resolvers.JobTracking.move_candidate/3)
     end

--- a/lib/wttj/statuses/status.ex
+++ b/lib/wttj/statuses/status.ex
@@ -8,6 +8,7 @@ defmodule Wttj.Statuses.Status do
     field :position, :integer
     field :job_id, :id
 
+    field :lock_version, :integer, default: 1
     has_many :candidates, Candidate
 
     timestamps(type: :utc_datetime)

--- a/lib/wttj/statuses/status.ex
+++ b/lib/wttj/statuses/status.ex
@@ -17,7 +17,7 @@ defmodule Wttj.Statuses.Status do
   @doc false
   def changeset(status, attrs) do
     status
-    |> cast(attrs, [:label, :position, :job_id])
+    |> cast(attrs, [:label, :lock_version, :position, :job_id])
     |> validate_required([:label, :position, :job_id])
   end
 end

--- a/lib/wttj/types/schema_types.ex
+++ b/lib/wttj/types/schema_types.ex
@@ -30,6 +30,7 @@ defmodule Wttj.Types.SchemaTypes do
     field :label, :string
     field :position, :integer
     field :job_id, :id
+    field :lock_version, :integer
   end
 
   @desc "Contains the details of a specific candidate"
@@ -46,6 +47,14 @@ defmodule Wttj.Types.SchemaTypes do
   object :candidate_moved do
     field :candidate, :candidate
     field :client_id, :string
+    field :source_status, :status
+    field :destination_status, :status
+  end
+
+  object :move_candidate_result do
+    field :candidate, :candidate
+    field :source_status, :status
+    field :destination_status, :status
   end
 
 end

--- a/priv/repo/migrations/20250120115911_add_lock_version_to_statuses.exs
+++ b/priv/repo/migrations/20250120115911_add_lock_version_to_statuses.exs
@@ -1,0 +1,15 @@
+defmodule Wttj.Repo.Migrations.AddLockVersionToStatuses do
+  use Ecto.Migration
+
+  def change do
+    alter table(:statuses) do
+      add :lock_version, :integer, default: 1, null: false
+    end
+  end
+
+  def down do
+    alter table(:statuses) do
+      remove :lock_version
+    end
+  end
+end

--- a/test/wttj/candidates_test.exs
+++ b/test/wttj/candidates_test.exs
@@ -18,76 +18,147 @@ defmodule Wttj.CandidatesTest do
     {:ok, job1: job1, job2: job2, status1: status1, status2: status2, status3: status3}
   end
 
-  describe "candidates (existing tests)" do
-    alias Wttj.Candidates.Candidate
+  @before_index_version 1
+  @after_index_version 1
 
-    import Wttj.CandidatesFixtures
+  # describe "candidates (existing tests)" do
+  #   alias Wttj.Candidates.Candidate
 
-    @invalid_attrs %{position: nil, status: nil, email: nil}
+  #   import Wttj.CandidatesFixtures
 
-    test "list_candidates/1 returns all candidates for a given job", %{
-      job1: job1,
-      job2: job2,
-      status1: status1,
-      status2: status2
-    } do
-      candidate1 =
-        candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+  #   @invalid_attrs %{position: nil, status: nil, email: nil}
 
-      _ = candidate_fixture(%{job_id: job2.id, status_id: status2.id, display_order: "1"})
-      assert Candidates.list_candidates(job1.id) == [candidate1]
-    end
+  #   test "list_candidates/1 returns all candidates for a given job", %{
+  #     job1: job1,
+  #     job2: job2,
+  #     status1: status1,
+  #     status2: status2
+  #   } do
+  #     candidate1 =
+  #       candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
 
-    test "create_candidate/1 with valid data creates a candidate", %{job1: job1, status1: status1} do
-      email = unique_user_email()
+  #     _ = candidate_fixture(%{job_id: job2.id, status_id: status2.id, display_order: "1"})
+  #     assert Candidates.list_candidates(job1.id) == [candidate1]
+  #   end
 
-      valid_attrs = %{
-        email: email,
-        position: 3,
-        job_id: job1.id,
-        status_id: status1.id,
-        display_order: "1"
-      }
+  #   test "create_candidate/1 with valid data creates a candidate", %{job1: job1, status1: status1} do
+  #     email = unique_user_email()
 
-      assert {:ok, %Candidate{} = candidate} = Candidates.create_candidate(valid_attrs)
-      assert candidate.email == email
-      assert {:error, _} = Candidates.create_candidate()
-    end
+  #     valid_attrs = %{
+  #       email: email,
+  #       position: 3,
+  #       job_id: job1.id,
+  #       status_id: status1.id,
+  #       display_order: "1"
+  #     }
 
-    test "update_candidate/2 with valid data updates the candidate", %{
-      job1: job1,
-      status1: status1
-    } do
-      candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
-      email = unique_user_email()
-      update_attrs = %{position: 43, status: :rejected, email: email, status_id: status1.id}
+  #     assert {:ok, %Candidate{} = candidate} = Candidates.create_candidate(valid_attrs)
+  #     assert candidate.email == email
+  #     assert {:error, _} = Candidates.create_candidate()
+  #   end
 
-      assert {:ok, %Candidate{} = candidate} =
-               Candidates.update_candidate(candidate, update_attrs)
+  #   test "update_candidate/2 with valid data updates the candidate", %{
+  #     job1: job1,
+  #     status1: status1
+  #   } do
+  #     candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+  #     email = unique_user_email()
+  #     update_attrs = %{position: 43, status: :rejected, email: email, status_id: status1.id}
 
-      assert candidate.position == 43
-      assert candidate.status_id == status1.id
-      assert candidate.email == email
-    end
+  #     assert {:ok, %Candidate{} = candidate} =
+  #              Candidates.update_candidate(candidate, update_attrs)
 
-    test "update_candidate/2 with invalid data returns error changeset", %{
-      job1: job1,
-      status1: status1
-    } do
-      candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
-      assert {:error, %Ecto.Changeset{}} = Candidates.update_candidate(candidate, @invalid_attrs)
-      assert candidate == Candidates.get_candidate!(job1.id, candidate.id)
-    end
+  #     assert candidate.position == 43
+  #     assert candidate.status_id == status1.id
+  #     assert candidate.email == email
+  #   end
 
-    test "change_candidate/1 returns a candidate changeset", %{job1: job1, status1: status1} do
-      candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
-      assert %Ecto.Changeset{} = Candidates.change_candidate(candidate)
-    end
-  end
+  #   test "update_candidate/2 with invalid data returns error changeset", %{
+  #     job1: job1,
+  #     status1: status1
+  #   } do
+  #     candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+  #     assert {:error, %Ecto.Changeset{}} = Candidates.update_candidate(candidate, @invalid_attrs)
+  #     assert candidate == Candidates.get_candidate!(job1.id, candidate.id)
+  #   end
 
-  describe "update_candidate_display_order/3 when checking status" do
-    test "returns error when status doesnt belong to job",
-         %{job1: job1, status1: status1, status3: status3} do
+  #   test "change_candidate/1 returns a candidate changeset", %{job1: job1, status1: status1} do
+  #     candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+  #     assert %Ecto.Changeset{} = Candidates.change_candidate(candidate)
+  #   end
+  # end
+
+  # describe "update_candidate_display_order/3 when checking status" do
+  #   test "returns error when status doesnt belong to job",
+  #        %{job1: job1, status1: status1, status3: status3} do
+  #     # Arrange
+  #     candidate =
+  #       candidate_fixture(%{
+  #         job_id: job1.id,
+  #         status_id: status1.id,
+  #         display_order: "1"
+  #       })
+
+  #     # Act
+  #     result = Candidates.update_candidate_display_order(candidate.id, nil, nil, status3.id)
+
+  #     # Assert
+  #     assert result == {:error, "status does not belong to job"}
+  #   end
+
+  #   test "returns error when status not found",
+  #        %{job1: job1, status1: status1} do
+  #     # Arrange
+  #     candidate =
+  #       candidate_fixture(%{
+  #         job_id: job1.id,
+  #         status_id: status1.id,
+  #         display_order: "1",
+  #       })
+
+  #     # Act
+  #     result = Candidates.update_candidate_display_order(candidate.id, nil, nil, 100)
+
+  #     # Assert
+  #     assert result == {:error, "status not found"}
+  #   end
+  # end
+
+  # describe "update_candidate_display_order/3 when candidate doesnt exist in the database" do
+  #   test "returns error" do
+  #     # Arrange
+  #     candidate_id = 100
+
+  #     # Act
+  #     result = Candidates.update_candidate_display_order(candidate_id, nil, nil)
+
+  #     # Assert
+  #     assert result == {:error, "candidate not found"}
+  #   end
+  # end
+
+  # describe "update_candidate_display_order/3 when moving a candidate with the same empty list" do
+  #   test "returns error when to same list",
+  #        %{job1: job1, status1: status1} do
+  #     # Arrange
+  #     candidate =
+  #       candidate_fixture(%{
+  #         job_id: job1.id,
+  #         status_id: status1.id,
+  #         display_order: "1"
+  #       })
+
+  #     # Act
+  #     result = Candidates.update_candidate_display_order(candidate.id, nil, nil, status1.id)
+
+  #     # Assert
+  #     assert result == {:error, "candidate already exists in the list youre trying to move it to"}
+  #   end
+  # end
+
+  describe "update_candidate_display_order/3 returns a version mismatch error" do
+    test "returns error when version mismatch",
+         %{job1: job1, status1: status1, status2: status2} do
       # Arrange
       candidate =
         candidate_fixture(%{
@@ -96,60 +167,21 @@ defmodule Wttj.CandidatesTest do
           display_order: "1"
         })
 
-      # Act
-      result = Candidates.update_candidate_display_order(candidate.id, nil, nil, status3.id)
-
-      # Assert
-      assert result == {:error, "status does not belong to job"}
-    end
-
-    test "returns error when status not found",
-         %{job1: job1, status1: status1} do
-      # Arrange
-      candidate =
-        candidate_fixture(%{
-          job_id: job1.id,
-          status_id: status1.id,
-          display_order: "1",
-        })
+      before_index_version = 2
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate.id, nil, nil, 100)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate.id,
+          nil,
+          nil,
+          before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
-      assert result == {:error, "status not found"}
-    end
-  end
-
-  describe "update_candidate_display_order/3 when candidate doesnt exist in the database" do
-    test "returns error" do
-      # Arrange
-      candidate_id = 100
-
-      # Act
-      result = Candidates.update_candidate_display_order(candidate_id, nil, nil)
-
-      # Assert
-      assert result == {:error, "candidate not found"}
-    end
-  end
-
-  describe "update_candidate_display_order/3 when moving a candidate with the same empty list" do
-    test "returns error when to same list",
-         %{job1: job1, status1: status1} do
-      # Arrange
-      candidate =
-        candidate_fixture(%{
-          job_id: job1.id,
-          status_id: status1.id,
-          display_order: "1"
-        })
-
-      # Act
-      result = Candidates.update_candidate_display_order(candidate.id, nil, nil, status1.id)
-
-      # Assert
-      assert result == {:error, "candidate already exists in the list youre trying to move it to"}
+      assert result == {:error, :version_mismatch}
     end
   end
 
@@ -158,10 +190,10 @@ defmodule Wttj.CandidatesTest do
          %{job1: job1, status1: status1, status2: status2} do
       # Arrange
       candidate_fixture(%{
-          job_id: job1.id,
-          status_id: status1.id,
-          display_order: "1"
-        })
+        job_id: job1.id,
+        status_id: status1.id,
+        display_order: "1"
+      })
 
       candiate_in_status_2 =
         candidate_fixture(%{
@@ -172,7 +204,14 @@ defmodule Wttj.CandidatesTest do
 
       # Act
       result =
-        Candidates.update_candidate_display_order(candiate_in_status_2.id, nil, nil, status1.id)
+        Candidates.update_candidate_display_order(
+          candiate_in_status_2.id,
+          nil,
+          nil,
+          @before_index_version,
+          status1.id,
+          @after_index_version
+        )
 
       # Assert
       assert result == {:error, "cannot insert first candidate in list. others already present"}
@@ -189,7 +228,15 @@ defmodule Wttj.CandidatesTest do
         })
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate.id, nil, nil, status2.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate.id,
+          nil,
+          nil,
+          @before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:ok, candidate} = result
@@ -226,7 +273,9 @@ defmodule Wttj.CandidatesTest do
           candidate2.id,
           nil,
           candidate1.display_order,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -268,7 +317,9 @@ defmodule Wttj.CandidatesTest do
           candidate3.id,
           nil,
           candidate2.display_order,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -284,7 +335,15 @@ defmodule Wttj.CandidatesTest do
         candidate_fixture(%{job_id: job1.id, status_id: status2.id, display_order: "2"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate2.id, nil, "1.5", status2.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate2.id,
+          nil,
+          "1.5",
+          @before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:error, "candidate not found with matching display order"} = result
@@ -297,7 +356,15 @@ defmodule Wttj.CandidatesTest do
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate1.id, nil, "1", status1.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate1.id,
+          nil,
+          "1",
+          @before_index_version,
+          status1.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:error, "no candidates found within range"} = result
@@ -320,7 +387,9 @@ defmodule Wttj.CandidatesTest do
           candidate2.id,
           nil,
           candidate1.display_order,
-          status2.id
+          @before_index_version,
+          status2.id,
+          @after_index_version
         )
 
       # Assert
@@ -351,7 +420,9 @@ defmodule Wttj.CandidatesTest do
           candidate3.id,
           nil,
           candidate2.display_order,
-          status2.id
+          @before_index_version,
+          status2.id,
+          @after_index_version
         )
 
       # Assert
@@ -368,7 +439,15 @@ defmodule Wttj.CandidatesTest do
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "8"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate2.id, nil, "1.5", status2.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate2.id,
+          nil,
+          "1.5",
+          @before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:error, "candidate not found with matching display order"} = result
@@ -381,10 +460,18 @@ defmodule Wttj.CandidatesTest do
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate1.id, nil, "1", status2.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate1.id,
+          nil,
+          "1",
+          @before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
-      assert {:error, "no candidates found within range"} = result
+      assert {:error, "no candidates found within range"} == result
     end
   end
 
@@ -404,7 +491,9 @@ defmodule Wttj.CandidatesTest do
           candidate1.id,
           candidate2.display_order,
           nil,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -434,7 +523,9 @@ defmodule Wttj.CandidatesTest do
           candidate1.id,
           candidate2.display_order,
           nil,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -450,7 +541,15 @@ defmodule Wttj.CandidatesTest do
       candidate_fixture(%{job_id: job1.id, status_id: status2.id, display_order: "2"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate1.id, "1.5", nil, status2.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate1.id,
+          "1.5",
+          nil,
+          @before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:error, "candidate not found with matching display order"} = result
@@ -463,7 +562,15 @@ defmodule Wttj.CandidatesTest do
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate1.id, "1", nil, status1.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate1.id,
+          "1",
+          nil,
+          @before_index_version,
+          status1.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:error, "no candidates found within range"} = result
@@ -486,7 +593,9 @@ defmodule Wttj.CandidatesTest do
           candidate2.id,
           candidate1.display_order,
           nil,
-          status2.id
+          @before_index_version,
+          status2.id,
+          @after_index_version
         )
 
       # Assert
@@ -516,7 +625,9 @@ defmodule Wttj.CandidatesTest do
           candidate1.id,
           candidate2.display_order,
           nil,
-          status2.id
+          @before_index_version,
+          status2.id,
+          @after_index_version
         )
 
       # Assert
@@ -532,7 +643,15 @@ defmodule Wttj.CandidatesTest do
       candidate_fixture(%{job_id: job1.id, status_id: status2.id, display_order: "2"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate1.id, "1.5", nil, status2.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate1.id,
+          "1.5",
+          nil,
+          @before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:error, "candidate not found with matching display order"} = result
@@ -545,7 +664,15 @@ defmodule Wttj.CandidatesTest do
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
 
       # Act
-      result = Candidates.update_candidate_display_order(candidate1.id, "1", nil, status2.id)
+      result =
+        Candidates.update_candidate_display_order(
+          candidate1.id,
+          "1",
+          nil,
+          @before_index_version,
+          status2.id,
+          @after_index_version
+        )
 
       # Assert
       assert {:error, "no candidates found within range"} = result
@@ -571,7 +698,9 @@ defmodule Wttj.CandidatesTest do
           candidate3.id,
           candidate1.display_order,
           candidate2.display_order,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -604,7 +733,9 @@ defmodule Wttj.CandidatesTest do
           candidate4.id,
           candidate1.display_order,
           candidate3.display_order,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -628,7 +759,9 @@ defmodule Wttj.CandidatesTest do
           candidate3.id,
           candidate1.display_order,
           "1.9",
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -655,7 +788,9 @@ defmodule Wttj.CandidatesTest do
           candidate3.id,
           candidate1.display_order,
           candidate2.display_order,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -688,7 +823,9 @@ defmodule Wttj.CandidatesTest do
           candidate4.id,
           candidate1.display_order,
           candidate3.display_order,
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert
@@ -724,7 +861,9 @@ defmodule Wttj.CandidatesTest do
           candidate3.id,
           candidate1.display_order,
           "1.9",
-          status1.id
+          @before_index_version,
+          status1.id,
+          @after_index_version
         )
 
       # Assert

--- a/test/wttj/candidates_test.exs
+++ b/test/wttj/candidates_test.exs
@@ -244,11 +244,8 @@ defmodule Wttj.CandidatesTest do
   end
 
   describe "update_candidate_display_order/3 updates status version number" do
-    # when source version number doesnt match
-    # when destination version number doesnt match
-
     test "when moving candidate within same column",
-         %{job1: job1, status1: status1, status2: status2} do
+         %{job1: job1, status1: status1} do
       # Arrange
       candidate1 =
         candidate_fixture(%{

--- a/test/wttj/candidates_test.exs
+++ b/test/wttj/candidates_test.exs
@@ -21,140 +21,170 @@ defmodule Wttj.CandidatesTest do
   @before_index_version 1
   @after_index_version 1
 
-  # describe "candidates (existing tests)" do
-  #   alias Wttj.Candidates.Candidate
+  describe "candidates (existing tests)" do
+    alias Wttj.Candidates.Candidate
 
-  #   import Wttj.CandidatesFixtures
+    import Wttj.CandidatesFixtures
 
-  #   @invalid_attrs %{position: nil, status: nil, email: nil}
+    @invalid_attrs %{position: nil, status: nil, email: nil}
 
-  #   test "list_candidates/1 returns all candidates for a given job", %{
-  #     job1: job1,
-  #     job2: job2,
-  #     status1: status1,
-  #     status2: status2
-  #   } do
-  #     candidate1 =
-  #       candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+    test "list_candidates/1 returns all candidates for a given job", %{
+      job1: job1,
+      job2: job2,
+      status1: status1,
+      status2: status2
+    } do
+      candidate1 =
+        candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
 
-  #     _ = candidate_fixture(%{job_id: job2.id, status_id: status2.id, display_order: "1"})
-  #     assert Candidates.list_candidates(job1.id) == [candidate1]
-  #   end
+      _ = candidate_fixture(%{job_id: job2.id, status_id: status2.id, display_order: "1"})
+      assert Candidates.list_candidates(job1.id) == [candidate1]
+    end
 
-  #   test "create_candidate/1 with valid data creates a candidate", %{job1: job1, status1: status1} do
-  #     email = unique_user_email()
+    test "create_candidate/1 with valid data creates a candidate", %{job1: job1, status1: status1} do
+      email = unique_user_email()
 
-  #     valid_attrs = %{
-  #       email: email,
-  #       position: 3,
-  #       job_id: job1.id,
-  #       status_id: status1.id,
-  #       display_order: "1"
-  #     }
+      valid_attrs = %{
+        email: email,
+        position: 3,
+        job_id: job1.id,
+        status_id: status1.id,
+        display_order: "1"
+      }
 
-  #     assert {:ok, %Candidate{} = candidate} = Candidates.create_candidate(valid_attrs)
-  #     assert candidate.email == email
-  #     assert {:error, _} = Candidates.create_candidate()
-  #   end
+      assert {:ok, %Candidate{} = candidate} = Candidates.create_candidate(valid_attrs)
+      assert candidate.email == email
+      assert {:error, _} = Candidates.create_candidate()
+    end
 
-  #   test "update_candidate/2 with valid data updates the candidate", %{
-  #     job1: job1,
-  #     status1: status1
-  #   } do
-  #     candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
-  #     email = unique_user_email()
-  #     update_attrs = %{position: 43, status: :rejected, email: email, status_id: status1.id}
+    test "update_candidate/2 with valid data updates the candidate", %{
+      job1: job1,
+      status1: status1
+    } do
+      candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+      email = unique_user_email()
+      update_attrs = %{position: 43, status: :rejected, email: email, status_id: status1.id}
 
-  #     assert {:ok, %Candidate{} = candidate} =
-  #              Candidates.update_candidate(candidate, update_attrs)
+      assert {:ok, %Candidate{} = candidate} =
+               Candidates.update_candidate(candidate, update_attrs)
 
-  #     assert candidate.position == 43
-  #     assert candidate.status_id == status1.id
-  #     assert candidate.email == email
-  #   end
+      assert candidate.position == 43
+      assert candidate.status_id == status1.id
+      assert candidate.email == email
+    end
 
-  #   test "update_candidate/2 with invalid data returns error changeset", %{
-  #     job1: job1,
-  #     status1: status1
-  #   } do
-  #     candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
-  #     assert {:error, %Ecto.Changeset{}} = Candidates.update_candidate(candidate, @invalid_attrs)
-  #     assert candidate == Candidates.get_candidate!(job1.id, candidate.id)
-  #   end
+    test "update_candidate/2 with invalid data returns error changeset", %{
+      job1: job1,
+      status1: status1
+    } do
+      candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+      assert {:error, %Ecto.Changeset{}} = Candidates.update_candidate(candidate, @invalid_attrs)
+      assert candidate == Candidates.get_candidate!(job1.id, candidate.id)
+    end
 
-  #   test "change_candidate/1 returns a candidate changeset", %{job1: job1, status1: status1} do
-  #     candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
-  #     assert %Ecto.Changeset{} = Candidates.change_candidate(candidate)
-  #   end
-  # end
+    test "change_candidate/1 returns a candidate changeset", %{job1: job1, status1: status1} do
+      candidate = candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+      assert %Ecto.Changeset{} = Candidates.change_candidate(candidate)
+    end
+  end
 
-  # describe "update_candidate_display_order/3 when checking status" do
-  #   test "returns error when status doesnt belong to job",
-  #        %{job1: job1, status1: status1, status3: status3} do
-  #     # Arrange
-  #     candidate =
-  #       candidate_fixture(%{
-  #         job_id: job1.id,
-  #         status_id: status1.id,
-  #         display_order: "1"
-  #       })
+  describe "update_candidate_display_order/3 when checking status" do
+    test "returns error when status doesnt belong to job",
+         %{job1: job1, status1: status1, status3: status3} do
+      # Arrange
+      candidate =
+        candidate_fixture(%{
+          job_id: job1.id,
+          status_id: status1.id,
+          display_order: "1"
+        })
 
-  #     # Act
-  #     result = Candidates.update_candidate_display_order(candidate.id, nil, nil, status3.id)
+      # Act
+      result =
+        Candidates.update_candidate_display_order(
+          candidate.id,
+          nil,
+          nil,
+          @before_index_version,
+          status3.id,
+          @after_index_version
+        )
 
-  #     # Assert
-  #     assert result == {:error, "status does not belong to job"}
-  #   end
+      # Assert
+      assert result == {:error, "status does not belong to job"}
+    end
 
-  #   test "returns error when status not found",
-  #        %{job1: job1, status1: status1} do
-  #     # Arrange
-  #     candidate =
-  #       candidate_fixture(%{
-  #         job_id: job1.id,
-  #         status_id: status1.id,
-  #         display_order: "1",
-  #       })
+    test "returns error when status not found",
+         %{job1: job1, status1: status1} do
+      # Arrange
+      candidate =
+        candidate_fixture(%{
+          job_id: job1.id,
+          status_id: status1.id,
+          display_order: "1"
+        })
 
-  #     # Act
-  #     result = Candidates.update_candidate_display_order(candidate.id, nil, nil, 100)
+      # Act
+      result =
+        Candidates.update_candidate_display_order(
+          candidate.id,
+          nil,
+          nil,
+          @before_index_version,
+          100,
+          @after_index_version
+        )
 
-  #     # Assert
-  #     assert result == {:error, "status not found"}
-  #   end
-  # end
+      # Assert
+      assert result == {:error, "status not found"}
+    end
+  end
 
-  # describe "update_candidate_display_order/3 when candidate doesnt exist in the database" do
-  #   test "returns error" do
-  #     # Arrange
-  #     candidate_id = 100
+  describe "update_candidate_display_order/3 when candidate doesnt exist in the database" do
+    test "returns error" do
+      # Arrange
+      candidate_id = 100
 
-  #     # Act
-  #     result = Candidates.update_candidate_display_order(candidate_id, nil, nil)
+      # Act
+      result =
+        Candidates.update_candidate_display_order(
+          candidate_id,
+          nil,
+          nil,
+          @before_index_version
+        )
 
-  #     # Assert
-  #     assert result == {:error, "candidate not found"}
-  #   end
-  # end
+      # Assert
+      assert result == {:error, "candidate not found"}
+    end
+  end
 
-  # describe "update_candidate_display_order/3 when moving a candidate with the same empty list" do
-  #   test "returns error when to same list",
-  #        %{job1: job1, status1: status1} do
-  #     # Arrange
-  #     candidate =
-  #       candidate_fixture(%{
-  #         job_id: job1.id,
-  #         status_id: status1.id,
-  #         display_order: "1"
-  #       })
+  describe "update_candidate_display_order/3 when moving a candidate with the same empty list" do
+    test "returns error when to same list",
+         %{job1: job1, status1: status1} do
+      # Arrange
+      candidate =
+        candidate_fixture(%{
+          job_id: job1.id,
+          status_id: status1.id,
+          display_order: "1"
+        })
 
-  #     # Act
-  #     result = Candidates.update_candidate_display_order(candidate.id, nil, nil, status1.id)
+      # Act
+      result =
+        Candidates.update_candidate_display_order(
+          candidate.id,
+          nil,
+          nil,
+          @before_index_version,
+          status1.id,
+          @after_index_version
+        )
 
-  #     # Assert
-  #     assert result == {:error, "candidate already exists in the list youre trying to move it to"}
-  #   end
-  # end
+      # Assert
+      assert result == {:error, "candidate already exists in the list youre trying to move it to"}
+    end
+  end
 
   describe "update_candidate_display_order/3 returns a version mismatch error" do
     test "returns error when version mismatch",

--- a/test/wttj/candidates_test.exs
+++ b/test/wttj/candidates_test.exs
@@ -264,8 +264,6 @@ defmodule Wttj.CandidatesTest do
           display_order: "2"
         })
 
-      # before_status_version = 2
-
       # Act
       result =
         Candidates.update_candidate_display_order(
@@ -273,13 +271,10 @@ defmodule Wttj.CandidatesTest do
           candidate2.display_order,
           nil,
           @before_status_version
-          # status2.id,
-          # @after_status_version
         )
 
       # Assert
-
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "3"
       assert candidate.status_id == status1.id
 
@@ -298,7 +293,6 @@ defmodule Wttj.CandidatesTest do
           display_order: "1"
         })
 
-      # before_status_version = 2
 
       # Act
       result =
@@ -312,8 +306,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "1"
       assert candidate.status_id == status2.id
 
@@ -379,7 +372,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "1"
       assert candidate.status_id == status2.id
 
@@ -419,7 +412,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "0.5"
       assert candidate.status_id == status1.id
 
@@ -533,7 +526,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "0.5"
       assert candidate.status_id == status2.id
 
@@ -637,7 +630,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "3"
       assert candidate.status_id == status1.id
 
@@ -739,7 +732,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "3"
       assert candidate.status_id == status2.id
 
@@ -844,7 +837,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "1.5"
       assert candidate.status_id == status1.id
 
@@ -934,7 +927,7 @@ defmodule Wttj.CandidatesTest do
         )
 
       # Assert
-      assert {:ok, candidate} = result
+      assert {:ok, %{candidate: candidate}} = result
       assert candidate.display_order == "1.5"
       assert candidate.status_id == status1.id
 

--- a/test/wttj/resolvers/job_tracking_test.exs
+++ b/test/wttj/resolvers/job_tracking_test.exs
@@ -143,6 +143,13 @@ defmodule Wttj.Resolvers.JobTrackingTest do
         assert endpoint == WttjWeb.Endpoint
         assert payload.candidate.id == candidate.id
         assert payload.client_id == @clientId
+
+        assert payload.source_status.id == status1.id
+        assert payload.source_status.lock_version == 2
+
+        assert payload.destination_status.id == status2.id
+        assert payload.destination_status.lock_version == 2
+
         assert topic == [candidate_moved: "candidate_moved:#{job.id}"]
         :ok
       end)
@@ -150,7 +157,8 @@ defmodule Wttj.Resolvers.JobTrackingTest do
       result = JobTracking.move_candidate(nil, args, nil)
 
       # Assert
-      assert {:ok, %Candidate{}} = result
+      assert {:ok, %{candidate: candidate}} = result
+
     end
   end
 end

--- a/test/wttj/resolvers/job_tracking_test.exs
+++ b/test/wttj/resolvers/job_tracking_test.exs
@@ -86,6 +86,8 @@ defmodule Wttj.Resolvers.JobTrackingTest do
 
   describe "move_candidate/3" do
     @clientId "1234"
+    @destination_status_version 1
+    @before_index_version 1
 
     defmodule WTTJ.Subscription do
       @callback publish(Plug.Conn.t() | atom(), map(), keyword()) :: :ok | {:error, term()}
@@ -108,7 +110,9 @@ defmodule Wttj.Resolvers.JobTrackingTest do
       # Arrange
       args = %{
         candidate_id: 100,
-        client_id: @clientId
+        client_id: @clientId,
+        destination_status_version: @destination_status_version,
+        before_index_version: @before_index_version
       }
 
       # Act
@@ -130,7 +134,9 @@ defmodule Wttj.Resolvers.JobTrackingTest do
         before_index: nil,
         after_index: nil,
         destination_status_id: status2.id,
-        client_id: @clientId
+        client_id: @clientId,
+        destination_status_version: @destination_status_version,
+        before_index_version: @before_index_version
       }
 
       expect(MockSubscription, :publish, fn endpoint, payload, topic ->

--- a/test/wttj/resolvers/job_tracking_test.exs
+++ b/test/wttj/resolvers/job_tracking_test.exs
@@ -87,7 +87,7 @@ defmodule Wttj.Resolvers.JobTrackingTest do
   describe "move_candidate/3" do
     @clientId "1234"
     @destination_status_version 1
-    @before_index_version 1
+    @source_status_version 1
 
     defmodule WTTJ.Subscription do
       @callback publish(Plug.Conn.t() | atom(), map(), keyword()) :: :ok | {:error, term()}
@@ -112,7 +112,7 @@ defmodule Wttj.Resolvers.JobTrackingTest do
         candidate_id: 100,
         client_id: @clientId,
         destination_status_version: @destination_status_version,
-        before_index_version: @before_index_version
+        source_status_version: @source_status_version
       }
 
       # Act
@@ -136,7 +136,7 @@ defmodule Wttj.Resolvers.JobTrackingTest do
         destination_status_id: status2.id,
         client_id: @clientId,
         destination_status_version: @destination_status_version,
-        before_index_version: @before_index_version
+        source_status_version: @source_status_version
       }
 
       expect(MockSubscription, :publish, fn endpoint, payload, topic ->

--- a/test/wttj/resolvers/job_tracking_test.exs
+++ b/test/wttj/resolvers/job_tracking_test.exs
@@ -1,15 +1,10 @@
 defmodule Wttj.Resolvers.JobTrackingTest do
-  alias Wttj.Candidates.Candidate
   use Wttj.DataCase
   alias Wttj.Resolvers.JobTracking
   import Wttj.JobsFixtures
   import Wttj.StatusesFixtures
   import Wttj.CandidatesFixtures
   import Mox
-
-  # These tests should probably be mocked, instead of calling the database
-
-
 
   describe "get_job/3" do
     test "returns error when job not found" do
@@ -157,7 +152,7 @@ defmodule Wttj.Resolvers.JobTrackingTest do
       result = JobTracking.move_candidate(nil, args, nil)
 
       # Assert
-      assert {:ok, %{candidate: candidate}} = result
+      assert {:ok, %{candidate: _candidate}} = result
 
     end
   end

--- a/test/wttj/schema_test.exs
+++ b/test/wttj/schema_test.exs
@@ -248,12 +248,22 @@ defmodule Wttj.SchemaTest do
           clientId: $clientId,
           sourceStatusVersion: $sourceStatusVersion,
           destinationStatusVersion: $destinationStatusVersion) {
-          email
-          id
-          jobId
-          position
-          statusId
-          displayOrder
+          candidate {
+            id
+            email
+            jobId
+            position
+            displayOrder
+            statusId
+          }
+          sourceStatus {
+            id
+            lockVersion
+          }
+          destinationStatus {
+            id
+            lockVersion
+          }
         }
       }
     """
@@ -287,12 +297,22 @@ defmodule Wttj.SchemaTest do
       # Assert
       assert result.data == %{
                "moveCandidate" => %{
-                 "email" => candidate1.email,
-                 "id" => to_string(candidate1.id),
-                 "jobId" => to_string(candidate1.job_id),
-                 "position" => candidate1.position,
-                 "statusId" => to_string(status2.id),
-                 "displayOrder" => "1"
+                 "candidate" => %{
+                   "email" => candidate1.email,
+                   "id" => to_string(candidate1.id),
+                   "jobId" => to_string(candidate1.job_id),
+                   "position" => candidate1.position,
+                   "statusId" => to_string(status2.id),
+                   "displayOrder" => "1"
+                 },
+                 "destinationStatus" => %{
+                   "id" => to_string(status2.id),
+                   "lockVersion" => 2
+                 },
+                 "sourceStatus" => %{
+                   "id" => to_string(status1.id),
+                   "lockVersion" => 2
+                 }
                }
              }
     end
@@ -304,7 +324,9 @@ defmodule Wttj.SchemaTest do
 
       candidate1 =
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+
       candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "2"})
+
       candidate3 =
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "3"})
 
@@ -317,19 +339,26 @@ defmodule Wttj.SchemaTest do
             "candidateId" => candidate3.id,
             "afterIndex" => candidate1.display_order,
             "clientId" => @client_id,
-            "sourceStatusVersion" => @source_status_version,
+            "sourceStatusVersion" => @source_status_version
           }
         )
 
       # Assert
       assert result.data == %{
                "moveCandidate" => %{
-                 "email" => candidate3.email,
-                 "id" => to_string(candidate3.id),
-                 "jobId" => to_string(candidate3.job_id),
-                 "position" => candidate3.position,
-                 "statusId" => to_string(status1.id),
-                 "displayOrder" => "0.5"
+                 "candidate" => %{
+                   "email" => candidate3.email,
+                   "id" => to_string(candidate3.id),
+                   "jobId" => to_string(candidate3.job_id),
+                   "position" => candidate3.position,
+                   "statusId" => to_string(status1.id),
+                   "displayOrder" => "0.5"
+                 },
+                 "destinationStatus" => nil,
+                 "sourceStatus" => %{
+                   "id" => to_string(status1.id),
+                   "lockVersion" => 2
+                 }
                }
              }
     end
@@ -341,7 +370,9 @@ defmodule Wttj.SchemaTest do
 
       candidate1 =
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "1"})
+
       candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "2"})
+
       candidate3 =
         candidate_fixture(%{job_id: job1.id, status_id: status1.id, display_order: "3"})
 
@@ -354,19 +385,26 @@ defmodule Wttj.SchemaTest do
             "candidateId" => candidate1.id,
             "beforeIndex" => candidate3.display_order,
             "clientId" => @client_id,
-            "sourceStatusVersion" => @source_status_version,
+            "sourceStatusVersion" => @source_status_version
           }
         )
 
       # Assert
       assert result.data == %{
                "moveCandidate" => %{
-                 "email" => candidate1.email,
-                 "id" => to_string(candidate1.id),
-                 "jobId" => to_string(candidate1.job_id),
-                 "position" => candidate1.position,
-                 "statusId" => to_string(status1.id),
-                 "displayOrder" => "4"
+                 "candidate" => %{
+                   "email" => candidate1.email,
+                   "id" => to_string(candidate1.id),
+                   "jobId" => to_string(candidate1.job_id),
+                   "position" => candidate1.position,
+                   "statusId" => to_string(status1.id),
+                   "displayOrder" => "4"
+                 },
+                 "destinationStatus" => nil,
+                 "sourceStatus" => %{
+                   "id" => to_string(status1.id),
+                   "lockVersion" => 2
+                 }
                }
              }
     end
@@ -395,19 +433,26 @@ defmodule Wttj.SchemaTest do
             "beforeIndex" => candidate2.display_order,
             "afterIndex" => candidate3.display_order,
             "clientId" => @client_id,
-            "sourceStatusVersion" => @source_status_version,
+            "sourceStatusVersion" => @source_status_version
           }
         )
 
       # Assert
       assert result.data == %{
                "moveCandidate" => %{
-                 "email" => candidate1.email,
-                 "id" => to_string(candidate1.id),
-                 "jobId" => to_string(candidate1.job_id),
-                 "position" => candidate1.position,
-                 "statusId" => to_string(status1.id),
-                 "displayOrder" => "2.5"
+                 "candidate" => %{
+                   "email" => candidate1.email,
+                   "id" => to_string(candidate1.id),
+                   "jobId" => to_string(candidate1.job_id),
+                   "position" => candidate1.position,
+                   "statusId" => to_string(status1.id),
+                   "displayOrder" => "2.5"
+                 },
+                 "destinationStatus" => nil,
+                 "sourceStatus" => %{
+                   "id" => to_string(status1.id),
+                   "lockVersion" => 2
+                 }
                }
              }
     end
@@ -425,7 +470,7 @@ defmodule Wttj.SchemaTest do
             "beforeIndex" => "1.2s",
             "afterIndex" => "abcd",
             "clientId" => @client_id,
-            "sourceStatusVersion" => @source_status_version,
+            "sourceStatusVersion" => @source_status_version
           }
         )
 
@@ -450,7 +495,7 @@ defmodule Wttj.SchemaTest do
           Wttj.Schema,
           variables: %{
             "clientId" => @client_id,
-            "sourceStatusVersion" => @source_status_version,
+            "sourceStatusVersion" => @source_status_version
           }
         )
 
@@ -504,7 +549,7 @@ defmodule Wttj.SchemaTest do
           variables: %{
             "candidateId" => 100,
             "clientId" => @client_id,
-            "sourceStatusVersion" => @source_status_version,
+            "sourceStatusVersion" => @source_status_version
           }
         )
 
@@ -540,7 +585,7 @@ defmodule Wttj.SchemaTest do
             "beforeIndex" => candidate1.display_order,
             "afterIndex" => candidate3.display_order,
             "clientId" => @client_id,
-            "sourceStatusVersion" => @source_status_version,
+            "sourceStatusVersion" => @source_status_version
           }
         )
 

--- a/test/wttj/schema_test.exs
+++ b/test/wttj/schema_test.exs
@@ -232,8 +232,22 @@ defmodule Wttj.SchemaTest do
 
   describe "mutation :move_candidate" do
     @move_candidate_mutation """
-      mutation MoveCandidate($candidateId: ID! $beforeIndex: DisplayOrder, $afterIndex: DisplayOrder, $destinationStatusId: ID, $clientId: String!) {
-        moveCandidate(candidateId: $candidateId, beforeIndex: $beforeIndex, afterIndex: $afterIndex, destinationStatusId: $destinationStatusId, clientId: $clientId) {
+      mutation MoveCandidate(
+        $candidateId: ID!,
+        $beforeIndex: DisplayOrder,
+        $afterIndex: DisplayOrder,
+        $destinationStatusId: ID,
+        $clientId: String!,
+        $sourceStatusVersion: Int!,
+        $destinationStatusVersion: Int) {
+        moveCandidate(
+          candidateId: $candidateId,
+          beforeIndex: $beforeIndex,
+          afterIndex: $afterIndex,
+          destinationStatusId: $destinationStatusId,
+          clientId: $clientId,
+          sourceStatusVersion: $sourceStatusVersion,
+          destinationStatusVersion: $destinationStatusVersion) {
           email
           id
           jobId
@@ -244,6 +258,8 @@ defmodule Wttj.SchemaTest do
       }
     """
     @client_id "1234abcd"
+    @destination_status_version 1
+    @source_status_version 1
 
     test "returns ok when moving candidate to empty list" do
       # Arrange
@@ -262,7 +278,9 @@ defmodule Wttj.SchemaTest do
           variables: %{
             "candidateId" => candidate1.id,
             "destinationStatusId" => status2.id,
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
+            "destinationStatusVersion" => @destination_status_version
           }
         )
 
@@ -298,7 +316,8 @@ defmodule Wttj.SchemaTest do
           variables: %{
             "candidateId" => candidate3.id,
             "afterIndex" => candidate1.display_order,
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
           }
         )
 
@@ -334,7 +353,8 @@ defmodule Wttj.SchemaTest do
           variables: %{
             "candidateId" => candidate1.id,
             "beforeIndex" => candidate3.display_order,
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
           }
         )
 
@@ -374,7 +394,8 @@ defmodule Wttj.SchemaTest do
             "candidateId" => candidate1.id,
             "beforeIndex" => candidate2.display_order,
             "afterIndex" => candidate3.display_order,
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
           }
         )
 
@@ -403,7 +424,8 @@ defmodule Wttj.SchemaTest do
             "candidateId" => 100,
             "beforeIndex" => "1.2s",
             "afterIndex" => "abcd",
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
           }
         )
 
@@ -427,7 +449,8 @@ defmodule Wttj.SchemaTest do
           @move_candidate_mutation,
           Wttj.Schema,
           variables: %{
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
           }
         )
 
@@ -456,7 +479,9 @@ defmodule Wttj.SchemaTest do
           variables: %{
             "candidateId" => candidate1.id,
             "destinationStatusId" => status2.id,
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
+            "destinationStatusVersion" => @destination_status_version
           }
         )
 
@@ -478,7 +503,8 @@ defmodule Wttj.SchemaTest do
           Wttj.Schema,
           variables: %{
             "candidateId" => 100,
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
           }
         )
 
@@ -513,7 +539,8 @@ defmodule Wttj.SchemaTest do
             "candidateId" => candidate4.id,
             "beforeIndex" => candidate1.display_order,
             "afterIndex" => candidate3.display_order,
-            "clientId" => @client_id
+            "clientId" => @client_id,
+            "sourceStatusVersion" => @source_status_version,
           }
         )
 


### PR DESCRIPTION
Implement optimistic locking to handle concurrent changes.

- `lock_version`  field added to status (column). This is to keep track of changes with each column
- If any candidate order is updated within a column, it needs to be incremented
- Passing an outdated version number in a request will result in a `:version_mismatch` response
- Database update wrapped in a transaction, and relevant statuses are locked
- Source and destination statuses are returned to the frontend so that new updates can be sent