### PR TITLE
Feature/fix subscription error

### DIFF
--- a/assets/src/graphql/subscriptions/candidateMoved.ts
+++ b/assets/src/graphql/subscriptions/candidateMoved.ts
@@ -7,7 +7,6 @@ subscription TestSubscription($jobId: ID!) {
       id
       email
       jobId
-      position
       displayOrder
       columnId
     }


### PR DESCRIPTION
Graphql subscription fails because query includes position field, which has now been removed